### PR TITLE
Adding MSS530H to Case

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ class Meross {
         break;
       case "MSS510":
       case "MSS510M":
+      case 'MSS530H':
       case "MSS550":
       case "MSS560":
       case "MSS570":
@@ -111,6 +112,7 @@ class Meross {
         break;
       case 'MSS510':
       case 'MSS510M':
+      case 'MSS530H':
       case 'MSS550':
       case 'MSS570':
       case 'MSS5X0':


### PR DESCRIPTION
MSS530H is using the same JSON as MSS550 but you have to enter an ChannelID 1, 2 or 3.

Channel 1 is the Top Outlet, Channel 2 the bottom left and Channel 3 the bottom right.